### PR TITLE
Corrección de cálculo para las variables inversas

### DIFF
--- a/R/vulnerability_index.R
+++ b/R/vulnerability_index.R
@@ -84,7 +84,7 @@ vulnerability_index <- function(data, direct = NULL, inverse = NULL, table = NUL
       df_rank <- data %>%
         dplyr::mutate(
           dplyr::across({{ direct }}, dplyr::percent_rank),
-          dplyr::across({{ inverse }}, dplyr::percent_rank)
+          dplyr::across({{ inverse }}, ~ dplyr::percent_rank(desc(.)))
         ) %>%
         dplyr::rowwise()
 


### PR DESCRIPTION
La línea 87 no consideraba el factor inverso para las variables detectadas como tal. Es una modificación simple.